### PR TITLE
Support full content in RSS feeds 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 
 ## distill v0.7 (Development)
 
+* Add categories to rss feeds
 * Support rendering full RSS content when rss/full_content is TRUE in site config
 * Update to latest version of Distll template from https://github.com/distillpub/template
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 
 ## distill v0.7 (Development)
 
+* Support rendering full RSS content when rss/full_content is TRUE in site config
 * Update to latest version of Distll template from https://github.com/distillpub/template
 
 

--- a/R/collections.R
+++ b/R/collections.R
@@ -200,7 +200,8 @@ distill_article_post_processor <- function(encoding_fn, self_contained) {
       # publish article
       output_file <- publish_collection_article_to_site(
         site_dir, site_config, encoding, collection, article_path, metadata,
-        strip_trailing_newline = TRUE
+        strip_trailing_newline = TRUE,
+        input_file = input_file
       )
 
       # return the output_file w/ an attribute indicating that
@@ -215,7 +216,8 @@ distill_article_post_processor <- function(encoding_fn, self_contained) {
 
 publish_collection_article_to_site <- function(site_dir, site_config, encoding,
                                                collection, article_path, metadata,
-                                               strip_trailing_newline = FALSE) {
+                                               strip_trailing_newline = FALSE,
+                                               input_file = NULL) {
 
   # provide default date if we need to
   if (is.null(metadata[["date"]]))
@@ -233,7 +235,8 @@ publish_collection_article_to_site <- function(site_dir, site_config, encoding,
   # form an article object
   article <- list(
     path = article_path,
-    metadata = metadata
+    metadata = metadata,
+    input_file = input_file
   )
 
   # render the article
@@ -270,7 +273,8 @@ read_articles_json <- function(articles_file, site_dir, site_config, collection)
   articles
 }
 
-update_collection_listing <- function(site_dir, site_config, collection, article, encoding) {
+update_collection_listing <- function(site_dir, site_config, collection, article, encoding,
+                                      input_file) {
 
   # path to collection index
   collection_index <- file.path(site_dir, site_config$output_dir, collection$name,
@@ -783,7 +787,8 @@ article_info <- function(site_dir, article) {
     date = article$metadata$date,
     categories = as.list(article$metadata$categories),
     preview = resolve_preview_url(article$metadata$preview, path),
-    last_modified = time_as_iso_8601(file.info(article$path)$mtime)
+    last_modified = time_as_iso_8601(file.info(article$path)$mtime),
+    input_file = article$input_file
   )
 
   info$preview_width <- article$metadata$preview_width

--- a/R/sitemap.R
+++ b/R/sitemap.R
@@ -184,6 +184,12 @@ write_feed_xml <- function(feed_xml, site_config, collection, articles) {
       add_child(item, "description", text = not_null(article$description, default = article$title))
     }
 
+    if (!is.null(article$categories)) {
+      for (category in article$categories) {
+        add_child(item, "category", text = category)
+      }
+    }
+
     add_child(item, "guid", text = article$base_url)
     add_child(item, "pubDate", text = date_as_rfc_2822(article$date))
 


### PR DESCRIPTION
Fix for https://github.com/rstudio/distill/issues/33, adds support for RSS content with a `_site.yml` like:

```
name: "blog"
rss:
  full_content: TRUE
```

See for instance [_site.yml#L13-L14](https://github.com/rstudio/pins/blob/master/blog/_site.yml#L13-L14) which renders as [index.xml](https://rstudio.github.io/pins/blog/index.xml) / [preview](https://simplepie.org/demo/?feed=https%3A%2F%2Frstudio.github.io%2Fpins%2Fblog%2Findex.xml).

It also adds supports for [category](https://www.w3schools.com/xml/rss_tag_category_item.asp) elements which some feeds require.