### PR TITLE
Avoid base64 images when RSS uses full content

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 
 ## distill v0.7 (Development)
 
-* Add categories to rss feeds
+* Generate RSS category feeds using rss/categories in site config
 * Support rendering full RSS content when rss/full_content is TRUE in site config
 * Update to latest version of Distll template from https://github.com/distillpub/template
 * Provide aria attributes on toolbar icons


### PR DESCRIPTION
Follow up to https://github.com/rstudio/distill/pull/111.

Some blog aggregators like r-bloggers, do not a allow base64 encoded images. This PR adds relative images when `rss/full_content` is set in the `_site.yml` configuration file.

See for instance: https://rstudio.github.io/pins/blog/index.xml