### PR TITLE
Fix #121

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,7 @@ BugReports: https://github.com/rstudio/distill/issues
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.0.0
+RoxygenNote: 7.0.2
 Imports: 
     utils, 
     stats,

--- a/R/appendices.R
+++ b/R/appendices.R
@@ -109,6 +109,8 @@ appendix_citation <- function(site_config, metadata) {
 
   if (is_citeable(metadata)) {
 
+
+    # ToDo: it would be nicer if we could auto-generate short citation according to csl file user provides. `multiple-bibliographies.lua` (https://github.com/pandoc/lua-filters/tree/master/multiple-bibliographies) can be considered to avoid any conflict with main text references div.
     short_citation <- function() {
       if (!is.null(metadata$journal$title)) {
         sprintf('%s, "%s", %s, %s',
@@ -193,7 +195,7 @@ appendix_citation <- function(site_config, metadata) {
                       '  author = {%s},',
                       '  title = {%s},',
                       '  booktitle = {%s},',
-                      '  year = {%s}%s',
+                      '  year = {%s},',
                       '  month = {%s}%s',
                       sep = '\n'),
                 metadata$slug,
@@ -204,7 +206,7 @@ appendix_citation <- function(site_config, metadata) {
                 metadata$published_month,
                 suffix
         )
-      } else if (!is.null(metadata$thesis)) {
+      } else if (!is.null(metadata$thesis$type)) {
 
         suffix <- c()
         sep <- ifelse(!is.null(metadata$citation_url) && !is.null(metadata$doi), ",", "")
@@ -220,17 +222,22 @@ appendix_citation <- function(site_config, metadata) {
           suffix <- c(suffix, sprintf(',\n  publisher = {%s}', metadata$thesis$publisher))
         if (!is.null(metadata$thesis$firstpage) || !is.null(metadata$thesis$lastpage))
           suffix <- c(suffix, sprintf(',\n  pages = {%s}', paste0(c(metadata$thesis$firstpage, metadata$thesis$lastpage), collapse = "-")))
+        if (tolower(metadata$thesis$type) %in% c("phd", "masters")) {
+          thesis_entry <- sprintf(paste0('@', tolower(metadata$thesis$type), 'thesis{%s'), metadata$slug)
+        } else {
+          thesis_entry <- sprintf('@thesis{%s', metadata$slug)
+          suffix <- c(suffix, sprintf(',\n  type = {%s}', metadata$thesis$type))
+        }
         suffix <- paste0(c(suffix, '\n}'), collapse = '')
-        thesis_type <- ifelse(tolower(metadata$thesis$type) %in% c("phd", "master"), tolower(metadata$thesis$type), "phd")
-        sprintf(paste('@%sthesis{%s,',
+
+        sprintf(paste('%s,',
                       '  author = {%s},',
                       '  title = {%s},',
                       '  school = {%s},',
-                      '  year = {%s}%s',
+                      '  year = {%s},',
                       '  month = {%s}%s',
                       sep = '\n'),
-                thesis_type,
-                metadata$slug,
+                thesis_entry,
                 metadata$bibtex_authors,
                 qualified_title(site_config, metadata),
                 metadata$author[[1]]$affiliation,
@@ -238,7 +245,7 @@ appendix_citation <- function(site_config, metadata) {
                 metadata$published_month,
                 suffix
         )
-      } else if (!is.null(metadata$technical_report)) {
+      } else if (length(metadata$technical_report) != 0) {
 
         suffix <- c()
         sep <- ifelse(!is.null(metadata$citation_url) && !is.null(metadata$doi), ",", "")
@@ -257,12 +264,11 @@ appendix_citation <- function(site_config, metadata) {
         if (!is.null(metadata$technical_report$number))
           suffix <- c(suffix, sprintf(',\n  number = {%s}', metadata$technical_report$number))
         suffix <- paste0(c(suffix, '\n}'), collapse = '')
-        technical_report_type <- ifelse(tolower(metadata$technical_report$type) %in% c("phd", "master"), tolower(metadata$technical_report$type), "phd")
         sprintf(paste('@techreport{%s,',
                       '  author = {%s},',
                       '  title = {%s},',
                       '  institution = {%s},',
-                      '  year = {%s}%s',
+                      '  year = {%s},',
                       '  month = {%s}%s',
                       sep = '\n'),
                 metadata$slug,

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -120,12 +120,17 @@ transform_metadata <- function(file, site_config, collection_config, metadata, a
     metadata$conference <- list()
   }
 
-  # normalize thesis (for citations)
+  # normalize thesis (for citations). This entry does need thesis type (e.g., "phd" or "masters") instead of title since thesis will use default page title.
   if (!is.null(metadata$thesis)) {
     if (is.character(metadata$thesis))
       metadata$thesis <- list(type = metadata$thesis)
   } else {
     metadata$thesis <- list()
+  }
+
+  # normalize technical_report (for citations). This entry only requires a list as a normalized base.
+  if (length(metadata$technical_report) == 0) {
+  metadata$technical_report <- list()
   }
 
   # resolve creative commons license
@@ -439,26 +444,30 @@ google_scholar_metadata <- function(site_config, metadata) {
   add_meta("citation_doi", metadata$doi)
   add_meta("citation_isbn", metadata$isbn)
   journal <- metadata$journal
-  journal_title <- if (!is.null(journal$full_title) )
-    journal$full_title
-  else
-    journal$title
-  add_meta("citation_journal_title", journal$title)
-  add_meta("citation_journal_abbrev", journal$abbrev_title)
-  add_meta("citation_issn", journal$issn)
-  add_meta("citation_publisher", journal$publisher)
-  add_meta("citation_firstpage", journal$firstpage)
-  add_meta("citation_lastpage", journal$lastpage)
+  if(length(journal) != 0) {
+    journal_title <- if (!is.null(journal$full_title) )
+      journal$full_title
+    else
+      journal$title
+    add_meta("citation_journal_title", journal$title)
+    add_meta("citation_journal_abbrev", journal$abbrev_title)
+    add_meta("citation_issn", journal$issn)
+    add_meta("citation_publisher", journal$publisher)
+    add_meta("citation_firstpage", journal$firstpage)
+    add_meta("citation_lastpage", journal$lastpage)
+  }
   conference <- metadata$conference
-  conference_title <- if (!is.null(conference$full_title) )
-    conference$full_title
-  else
-    conference$title
-  add_meta("citation_conference_title", conference$title)
-  add_meta("citation_issn", conference$issn)
-  add_meta("citation_publisher", conference$publisher)
-  add_meta("citation_firstpage", conference$firstpage)
-  add_meta("citation_lastpage", conference$lastpage)
+  if(length(conference) != 0) {
+    conference_title <- if (!is.null(conference$full_title) )
+      conference$full_title
+    else
+      conference$title
+    add_meta("citation_conference_title", conference$title)
+    add_meta("citation_issn", conference$issn)
+    add_meta("citation_publisher", conference$publisher)
+    add_meta("citation_firstpage", conference$firstpage)
+    add_meta("citation_lastpage", conference$lastpage)
+  }
   if (!is.null(metadata$creative_commons))
     add_meta("citation_fulltext_world_readable", "")
   citation_date <- sprintf("%s/%s/%s",
@@ -472,23 +481,27 @@ google_scholar_metadata <- function(site_config, metadata) {
     add_meta("citation_author", author$name)
     add_meta("citation_author_institution", author$affiliation)
   }
-  if (!is.null(metadata$thesis))
+  thesis <- metadata$thesis
+  if(length(thesis) != 0) {
     for (author in metadata$author) {
       add_meta("citation_dissertation_institution", author$affiliation)
     }
-  add_meta("citation_issn", thesis$issn)
-  add_meta("citation_publisher", thesis$publisher)
-  add_meta("citation_firstpage", thesis$firstpage)
-  add_meta("citation_lastpage", thesis$lastpage)
-  if (!is.null(metadata$technical_report))
+    add_meta("citation_issn", thesis$issn)
+    add_meta("citation_publisher", thesis$publisher)
+    add_meta("citation_firstpage", thesis$firstpage)
+    add_meta("citation_lastpage", thesis$lastpage)
+  }
+  technical_report <- metadata$technical_report
+  if(length(technical_report) != 0) {
     for (author in metadata$author) {
       add_meta("citation_technical_report_institution", author$affiliation)
     }
-  add_meta("citation_technical_report_number", technical_report$number)
-  add_meta("citation_issn", technical_report$issn)
-  add_meta("citation_publisher", technical_report$publisher)
-  add_meta("citation_firstpage", technical_report$firstpage)
-  add_meta("citation_lastpage", technical_report$lastpage)
+    add_meta("citation_technical_report_number", technical_report$number)
+    add_meta("citation_issn", technical_report$issn)
+    add_meta("citation_publisher", technical_report$publisher)
+    add_meta("citation_firstpage", technical_report$firstpage)  
+    add_meta("citation_lastpage", technical_report$lastpage)
+  }
 
   google_scholar_meta
 }

--- a/man/distill_website.Rd
+++ b/man/distill_website.Rd
@@ -9,7 +9,7 @@ distill_website(input, encoding = getOption("encoding"), ...)
 \arguments{
 \item{input}{Website directory (or the name of a file within the directory).}
 
-\item{encoding}{The encoding of the input file; see \code{\link[rmarkdown]{file}}.}
+\item{encoding}{Ignored. The encoding is always assumed to be UTF-8.}
 
 \item{...}{Currently unused.}
 }

--- a/man/publish_website.Rd
+++ b/man/publish_website.Rd
@@ -23,9 +23,6 @@ to the \code{name} provided in \verb{_site.yml} (or to the name of the site_dir 
 
 \item{method}{Publishing method (currently only "rsconnect" is available)}
 
-\item{server}{Server name. Required only if you use the same account name on
-multiple servers.}
-
 \item{account}{Account to deploy application to. This parameter is only required for
 the initial deployment of an application when there are multiple accounts configured
 on the system.}


### PR DESCRIPTION
The purpose of this PR is twofold: (1) addressing issue #121; and (2) securing stability for some added bib_entries introduced in PR #118.

I havve confirmed the following entries work without any issues while beautifully printing corresponding bib_entries.

# Conference entry
``` yaml
confrence: # You can directly provide conference title here just like journal entry.
  title: "test confrence"
```


When `confrence$title` is detected, long_citation uses `@conference` biblatex entry.

# Thesis entry

``` yaml
thesis: # You can directly provide thesis type here.
  type: "phd"
```

When type is "phd", it is matched with `@phdthesis` biblatex entry, when type is "masters", then the long_citation uses `@mastersthesis`. If users specify none of them for type metadata, the long_citation would look like the below:

```
@thesis{...,
...,
type = {user type value here}
}
```

This is the right convention following biblatex guidelines.

# Technical_report  entry

``` yaml
technical_report: # do not need any value; however, user can provide "true" or "yes" here to make their article as a technical report.
  # Other sub-metadata available here like other entries (e.g., publisher, firstpage, lastpage, etc.)
```

If technical_report is defined in YAML, the long_citation is matched with `@techreport`.

Of course, every single entries explained above are automatically matched with their appropriate Google Scholar meta tags.

I can make another PR to update distill documents to explain these newly added entries.