### PR TITLE
Support rss categories for blogs that already use rss

### DIFF
--- a/R/collections.R
+++ b/R/collections.R
@@ -279,7 +279,7 @@ move_feed_categories_xml <- function(main_feed, site_config) {
     category_filter <- paste0("/rss/channel/item/category[text()='", category, "']/..")
     filtered <- xml2::xml_find_all(posts, category_filter)
 
-    xml2::xml_remove(xml2::xml_find_first(posts, "/rss/channel/item"))
+    xml2::xml_remove(xml2::xml_find_all(posts, "/rss/channel/item"))
     channel_root <- xml2::xml_find_first(posts, "/rss/channel")
     for (entry in filtered) {
       xml2::xml_add_child(channel_root, entry)


### PR DESCRIPTION
When upgrading the tensorflow blog to support r-bloggers, it showed that current RSS categories functionality in distill, do not work with existing RSS. Fix here is to remove all the previous categories when generating the per-category RSS and then adding only the categories which match the category being built.

This fix only affects blogs using RSS feeds with `categories` being specified, which is probably just `pins` and now the `tensorflow` blog.