### PR TITLE
Navbar hex

### DIFF
--- a/inst/rmarkdown/templates/distill_article/resources/navbar.html
+++ b/inst/rmarkdown/templates/distill_article/resources/navbar.html
@@ -57,7 +57,7 @@
 
 .distill-site-nav {
   color: rgba(255, 255, 255, 0.8);
-  background-color: #455a64;
+  background-color: #0F2E3D;
   font-size: 15px;
   font-weight: 300;
 }

--- a/inst/rmarkdown/templates/distill_article/resources/search.html
+++ b/inst/rmarkdown/templates/distill_article/resources/search.html
@@ -153,7 +153,7 @@ window.document.addEventListener("DOMContentLoaded", function (event) {
   padding-top: 8px;
   padding-bottom: 0;
   border-radius: 6px;
-  border: 1px #455a64 solid;
+  border: 1px #0F2E3D solid;
   width: 180px;
 }
 


### PR DESCRIPTION
Hi @jjallaire,

I believe I found both templates where the navbar hex color was specified as `#455a64` and updated to match the current upper navbar for Distill <https://distill.pub/>: `#0F2E3D`

I unfortunately cannot re-render the docs site without seeing file path errors (opening up `docs.Rproj` and trying to build the site via the build pane or `rmarkdown::render()`). If there is a trick there, I'm happy to re-render the docs site too.

Thanks!
Alison