### PR TITLE
make the path relative for include_graphics

### DIFF
--- a/docs/_common/distill_basics.Rmd
+++ b/docs/_common/distill_basics.Rmd
@@ -65,7 +65,7 @@ ggplot(diamonds, aes(carat, price)) + geom_smooth() +
 ````
 
 ```{r, layout="l-body-outset"}
-include_graphics("~/packages/distill/docs/images/l-middle-figure.png")
+include_graphics("../images/l-middle-figure.png")
 ```
 
 Note that when specifying an alternate `layout` you should also specify an appropriate `fig.width` and `fig.height` for that layout. These values don't determine the absolute size of the figure (that's dynamic based on the layout) but they do determine the aspect ratio of the figure.


### PR DESCRIPTION
There was a call to `knitr::include_graphics()` with an absolute file path- changing it to relative allowed me to build the `docs/` site locally and in a GitHub Action 🎉 