### PR TITLE
Avoid cutoff rss in posts with tables

### DIFF
--- a/R/sitemap.R
+++ b/R/sitemap.R
@@ -126,7 +126,11 @@ write_feed_xml_html_content <- function(input_path, article, site_config) {
 
   # fix headers
   rmd_content <- paste0(readLines(input_path), collapse = "\n")
-  rmd_content <- gsub("---.*---", "", rmd_content)
+  headers <- stringr::str_locate_all(rmd_content, "---")
+  if (nrow(headers[[1]]) >= 2) {
+    rmd_content <- stringr::str_sub(rmd_content, headers[[1]][2,2] + 1)
+  }
+
   writeLines(rmd_content, rmd_file)
 
   # render doc


### PR DESCRIPTION
Blog posts with tables that contains tables, e.g.:

```
    +-------------------+-----+---------+
    |               time|value|value_sum|
    +-------------------+-----+---------+
    |1970-01-01 00:00:01|    1|      1.0|
    |1970-01-01 00:00:02|    4|      5.0|
    |1970-01-01 00:00:03|    9|     14.0|
    |1970-01-01 00:00:04|   16|     29.0|
    +-------------------+-----+---------+
```

would render the RSS cutoff since the current regular expression eagerly matches entries until an arbitrary `---` entry. Instead, we find all entries of `---` and remove from start to end of header using `stringr`.