### PR TITLE
Add default values for base-variables.css and base-style.css to read them in

### DIFF
--- a/inst/rmarkdown/templates/distill_article/resources/base-style.css
+++ b/inst/rmarkdown/templates/distill_article/resources/base-style.css
@@ -1,2 +1,74 @@
 
 /* base style */
+
+/*-- TITLE --*/
+d-title h1 {
+  font-size: var(--title-size);
+  color: var(--title-color);
+}
+
+/*-- BODY --*/
+d-article {
+  font-size: var(--body-size);
+  color: var(--body-color);
+}
+
+/*-- CODE --*/
+d-article div.sourceCode code,
+d-article pre code {
+	font-size: var(--code-size);
+}
+
+/*-- METADATA --*/
+d-byline h3 {
+	font-size: var(--byline-h3-size);
+	color: var(--byline-h3-color);
+}
+
+d-byline {
+	font-size: var(--byline-size);
+	color: var(--byline-color);
+}
+
+d-byline a,
+d-article d-byline a {
+	color: var(--byline-color);
+}
+
+/*-- TABLE OF CONTENTS --*/
+.d-contents nav h3 {
+	font-size: var(--toc-h3-size);
+	color: var(--toc-h3-color);
+}
+
+.d-contents nav a {
+	font-size: var(--toc-size);
+}
+
+/*-- APPENDIX --*/
+d-appendix h3 {
+  font-size: var(--appx-h3-size);
+	color: var(--appx-h3-color);
+}
+
+d-appendix {
+  font-size: var(--appx-size);
+	color: var(--appx-color);
+}
+
+d-footnote-list a.footnote-backlink {
+	color: var(--appx-color);
+}
+
+/*-- ASIDE --*/
+d-article aside {
+	font-size: var(--aside-size);
+	color: var(--aside-color);
+}
+
+/*-- FIGURE CAPTIONS --*/
+figure .caption,
+figure figcaption {
+	font-size: var(--fig-cap-size);
+	color: var(--fig-cap-color);
+}

--- a/inst/rmarkdown/templates/distill_article/resources/base-variables.css
+++ b/inst/rmarkdown/templates/distill_article/resources/base-variables.css
@@ -1,2 +1,27 @@
 
 /* base variables */
+
+:root {
+  /*-- font sizes --*/
+  --title-size:      50px;                /* default */
+  --body-size:       1.06rem;             /* default */
+  --code-size:       14px;                /* default */
+  --toc-h3-size:     18px;                /* default */
+  --toc-size:        13px;                /* default */
+  --byline-h3-size:  0.6rem;              /* default */
+  --byline-size:     0.8rem;              /* default */
+  --appx-h3-size:    15px;                /* default */
+  --appx-size:       0.8em;               /* default */
+  --aside-size:      12px;                /* default */
+  --fig-cap-size:    13px;                /* default */
+  /*-- font colors --*/
+  --title-color:     black;               /* default */
+  --body-color:      rgba(0, 0, 0, 0.8);  /* default */
+  --toc-h3-color:    rgba(0, 0, 0, 0.6);  /* default */
+  --byline-h3-color: rgba(0, 0, 0, 0.5);  /* default */
+  --byline-color:    rgba(0, 0, 0, 0.8);  /* default */
+  --appx-h3-color:   rgba(0, 0, 0, 0.65); /* default */
+  --appx-color:      rgba(0, 0, 0, 0.5);  /* default */
+  --aside-color:     rgba(0, 0, 0, 0.6);  /* default */
+  --fig-cap-color:   rgba(0, 0, 0, 0.6);  /* default */
+}


### PR DESCRIPTION
Hi @jjallaire,

On a visual test, I'm exactly replicating the default Distill article template. 

Next steps:

+ Add variables/styles for the default website/blog styles. For adding variables/styles to customize the [navbar](https://rstudio.github.io/distill/website.html#theming) for example, shall I add on to these two CSS files? 

+ Add docs for going deeper into customizing font families, since here we focused on font color and sizing.