### PR TITLE
Support rendering rss on render_site()

### DIFF
--- a/R/sitemap.R
+++ b/R/sitemap.R
@@ -236,9 +236,16 @@ write_feed_xml <- function(feed_xml, site_config, collection, articles) {
     add_child(item, "link", text = article$base_url)
 
     full_content_path <- NULL
-    if (identical(site_config$rss$full_content, TRUE) && is.character(article$input_file)) {
-      guess_rmd <- paste0(gsub("\\.utf.*\\.md|\\.md", "", article$input_file), ".Rmd")
-      full_content_path <- dir(getwd(), pattern = guess_rmd, full.names = TRUE, recursive = TRUE)
+    if (identical(site_config$rss$full_content, TRUE)) {
+      if (is.character(article$input_file)) {
+        guess_rmd <- paste0(gsub("\\.utf.*\\.md|\\.md", "", article$input_file), ".Rmd")
+        full_content_path <- dir(getwd(), pattern = guess_rmd, full.names = TRUE, recursive = TRUE)
+      }
+      else {
+        full_content_path <- Filter(
+          function(e) grepl(article$path, e, fixed = T),
+          dir(full.names = TRUE, pattern = "Rmd", recursive = TRUE))
+      }
     }
 
     if (length(full_content_path) > 0) {


### PR DESCRIPTION
Running `rmarkdown::render_site()` under the https://github.com/rstudio/ai-blog repo does not generate the RSS feed.

This fix searches for the active post being rendered and matches the `article$path` with the existing local path to the Rmd being generated.

Fix seems to work fine even when using `rmarkdown::render_site(input_path = "../ai-blog")`, likely due to `rmarkdown` setting a consistent path while building the site.