### PR TITLE
Support importing multiple fonts in a single @import request

### DIFF
--- a/R/distill_article.R
+++ b/R/distill_article.R
@@ -411,9 +411,9 @@ distill_in_header_html <- function(theme = NULL) {
       tags$style(type = "text/css", paste(xfun::read_utf8(file), collapse = "\n"))
     }
     theme_html <- tagList(
-      themeStyle(distill_resource("base-variables.css")),
-      themeStyle(theme),
-      themeStyle(distill_resource("base-style.css"))
+      htmltools::includeCSS(distill_resource("base-variables.css")),
+      htmltools::includeCSS(theme),
+      htmltools::includeCSS(distill_resource("base-style.css"))
     )
   } else {
     theme_html <- NULL

--- a/R/distill_article.R
+++ b/R/distill_article.R
@@ -407,9 +407,6 @@ distill_in_header_html <- function(theme = NULL) {
                 package = "distill")
   )
   if (!is.null(theme)) {
-    themeStyle <- function(file) {
-      tags$style(type = "text/css", paste(xfun::read_utf8(file), collapse = "\n"))
-    }
     theme_html <- tagList(
       htmltools::includeCSS(distill_resource("base-variables.css")),
       htmltools::includeCSS(theme),

--- a/R/distill_article.R
+++ b/R/distill_article.R
@@ -408,9 +408,9 @@ distill_in_header_html <- function(theme = NULL) {
   )
   if (!is.null(theme)) {
     theme_html <- tagList(
-      htmltools::includeCSS(distill_resource("base-variables.css")),
-      htmltools::includeCSS(theme),
-      htmltools::includeCSS(distill_resource("base-style.css"))
+      includeCSS(distill_resource("base-variables.css")),
+      includeCSS(theme),
+      includeCSS(distill_resource("base-style.css"))
     )
   } else {
     theme_html <- NULL

--- a/inst/rmarkdown/templates/distill_article/resources/base-variables.css
+++ b/inst/rmarkdown/templates/distill_article/resources/base-variables.css
@@ -4,6 +4,8 @@
 /* Edit the CSS properties in this file to create a custom
    Distill theme. Only edit values in the right column
    for each row; values shown are the CSS defaults.
+   To return any property to the default,
+   you may set its value to: unset
    All rows must end with a semi-colon.                      */
 
 /* Optional: embed custom fonts here with `@import`          */

--- a/inst/rmarkdown/templates/distill_article/resources/base-variables.css
+++ b/inst/rmarkdown/templates/distill_article/resources/base-variables.css
@@ -8,7 +8,6 @@
 
 /* Optional: embed custom fonts here with `@import`          */
 /* This must remain at the top of this file.                 */
-/* To import multiple fonts, use separate `@import` requests */
 
 
 


### PR DESCRIPTION
Hi @jjallaire,

Using [`htmltools::includeCSS()`](https://github.com/rstudio/htmltools/blob/master/R/tags.R#L1385-L1392) instead of `themeStyle()` includes all the dependencies from a combined `@import` request to the Google Font API. Here is an example of the request that now works when added at the top of my `theme.css`:

```
* Optional: embed custom fonts here with `@import`        */
@import url('https://fonts.googleapis.com/css2?family=DM+Mono&family=DM+Serif+Text&display=swap');
```

In the current dev version, here is what I see (the DM Serif Text font is not imported or applied to the headers; in testing, the first font is the only one that imports):

<img width="1037" alt="Screen Shot 2020-10-08 at 2 04 23 PM" src="https://user-images.githubusercontent.com/12160301/95496850-6a0a1e80-096f-11eb-95e2-14c8eac60814.png">

With this PR, I can use the second font in my import request:

<img width="1037" alt="Screen Shot 2020-10-08 at 2 05 01 PM" src="https://user-images.githubusercontent.com/12160301/95496972-9cb41700-096f-11eb-85bf-69cd1a01dc74.png">



This works, but I would appreciate your review to make sure there are no unexpected negatives for switching functions. Here is the function def:

```
#' @param ... Any additional attributes to be applied to the generated tag.
#' @rdname include
#' @export
includeCSS <- function(path, ...) {
  lines <- readLines(path, warn=FALSE, encoding='UTF-8')
  args <- dots_list(...)
  if (is.null(args$type))
    args$type <- 'text/css'
  return(do.call(tags$style,
    c(list(HTML(paste8(lines, collapse='\n'))), args)))
}
```


I edited the instructions in the `base-variables.css` file also, and clarified that you can return to any default CSS value using `unset`.

Will tackle updating docs and reference up next.

Alison