### PR TITLE
move listing$html to header before themes are loaded

### DIFF
--- a/R/distill_article.R
+++ b/R/distill_article.R
@@ -212,14 +212,14 @@ distill_article <- function(toc = FALSE,
                    metadata_json,
                    manifest_in_header(site_config, input_file, metadata, self_contained),
                    navigation_in_header_file(site_config),
+                   listing$html,
                    distill_in_header_file(theme))
 
     # before body includes: distill then user
     before_body <- c(front_matter_before_body(metadata),
                      navigation_before_body_file(dirname(input_file), site_config),
                      site_before_body_file(site_config),
-                     includes$before_body,
-                     listing$html)
+                     includes$before_body)
 
     # after body includes: user then distill
     after_body <- c(includes$after_body,


### PR DESCRIPTION
Hi @jjallaire,

The CSS properties don't cascade into the listing pages. See:

<img width="876" alt="Screen Shot 2020-10-09 at 11 46 31 AM" src="https://user-images.githubusercontent.com/12160301/95604179-4dc8b900-0a25-11eb-91ed-182361be9a4a.png">


I moved the `listing$html` up to just before the themes are loaded, and can now do:

<img width="876" alt="Screen Shot 2020-10-09 at 11 45 35 AM" src="https://user-images.githubusercontent.com/12160301/95604153-473a4180-0a25-11eb-97dc-e5f21bc0421f.png">


I am not seeing any immediate negative consequences of switching the order of these arguments in testing a new Distill article, website, or blog but please review 🤞 



Alison