### PR TITLE
remove use of pandoc_path_arg for highlight theme

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## distill v1.2 (Development)
+
+-   Fix an issue with highlighting on Windows when there is a space in the resource's path (\#236).
+
 ## distill v1.1 (CRAN)
 
 -   Fixed issue with `overflow: hidden` for code blocks on mobile devices (is now `overflow: auto`).

--- a/R/distill_article.R
+++ b/R/distill_article.R
@@ -293,14 +293,14 @@ distill_highlighting_args <- function(highlight) {
   #
   #   https://github.com/jgm/skylighting/blob/a1d02a0db6260c73aaf04aae2e6e18b569caacdc/skylighting-core/src/Skylighting/Format/HTML.hs#L117-L147
   #
-  default <- pandoc_path_arg(distill_resource("arrow.theme"))
+  default <- distill_resource("arrow.theme")
 
   # if it's "rstudio", then use an embedded theme file
   if (identical(highlight, "rstudio")) {
-    highlight <- pandoc_path_arg(distill_resource("rstudio.theme"))
+    highlight <- distill_resource("rstudio.theme")
   }
 
-  pandoc_highlight_args(highlight, default)
+  rmarkdown::pandoc_highlight_args(highlight, default)
 }
 
 knitr_preview_hook <- function(options) {


### PR DESCRIPTION
This should fix #214 

The issue is related to Pandoc - see https://github.com/rstudio/rmarkdown/issues/1976#issuecomment-741908329

This is a quick fix on **distill** side as `rmarkdown::pandoc_path_arg()` was used directly. 