### PR TITLE
create_theme() prints correct theme name argument, if not theme.css

### DIFF
--- a/R/theme.R
+++ b/R/theme.R
@@ -26,7 +26,7 @@ create_theme  <- function(name = "theme", edit = TRUE) {
   bullet <- "v"
   circle <- "o"
 
-  cat(paste(bullet, "Created CSS file at theme.css"), "\n", sep = "")
+  cat(paste(bullet, "Created CSS file at", css), "\n", sep = "")
   cat(paste(circle, "TODO: Customize it to suit your needs"), "\n", sep = "")
   cat(
     paste(circle, "TODO: Add 'theme' entry to your`site/article YAML\n"),

--- a/R/theme.R
+++ b/R/theme.R
@@ -29,9 +29,8 @@ create_theme  <- function(name = "theme", edit = TRUE) {
   cat(paste(bullet, "Created CSS file at", css), "\n", sep = "")
   cat(paste(circle, "TODO: Customize it to suit your needs"), "\n", sep = "")
   cat(
-    paste(circle, "TODO: Add 'theme' entry to your`site/article YAML\n"),
-    "\n", sep = ""
-    )
+    paste0("o ", "TODO: Add 'theme:", css, "' to your site or article YAML"),
+    "\n")
   cat("See docs at https://rstudio.github.io/distill/website.html#theming",
       sep = "")
 }

--- a/R/theme.R
+++ b/R/theme.R
@@ -26,11 +26,10 @@ create_theme  <- function(name = "theme", edit = TRUE) {
   bullet <- "v"
   circle <- "o"
 
-  cat(paste(bullet, "Created CSS file at", css), "\n", sep = "")
-  cat(paste(circle, "TODO: Customize it to suit your needs"), "\n", sep = "")
+  cat(paste(bullet, "Created CSS file at", css), "\n")
+  cat(paste(circle, "TODO: Customize it to suit your needs"), "\n")
   cat(
-    paste0("o ", "TODO: Add 'theme:", css, "' to your site or article YAML"),
+    paste0(circle, " ", "TODO: Add 'theme: ", css, "' to your site or article YAML"),
     "\n")
-  cat("See docs at https://rstudio.github.io/distill/website.html#theming",
-      sep = "")
+  cat("See docs at https://rstudio.github.io/distill/website.html#theming")
 }

--- a/R/theme.R
+++ b/R/theme.R
@@ -29,7 +29,7 @@ create_theme  <- function(name = "theme", edit = TRUE) {
   cat(paste(bullet, "Created CSS file at", css), "\n")
   cat(paste(circle, "TODO: Customize it to suit your needs"), "\n")
   cat(
-    paste0(circle, " ", "TODO: Add 'theme: ", css, "' to your site or article YAML"),
+    paste0(circle, " ", "TODO: Add 'theme: ", css, "' to your site or article YAML", "\n"),
     "\n")
   cat("See docs at https://rstudio.github.io/distill/website.html#theming")
 }


### PR DESCRIPTION
closes issue #235 and makes some improvements in formatting

current behavior:
```
create_theme("larug")
#> v Created CSS file at theme.css
#> o TODO: Customize it to suit your needs
#> o TODO: Add 'theme' entry to your`site/article YAML
#> 
#> See docs at https://rstudio.github.io/distill/website.html#theming
```

new behavior:
```
> create_theme()
v Created CSS file at theme.css 
o TODO: Customize it to suit your needs 
o TODO: Add 'theme: theme.css' to your site or article YAML 

See docs at https://rstudio.github.io/distill/website.html#theming
> create_theme("larug")
v Created CSS file at larug.css 
o TODO: Customize it to suit your needs 
o TODO: Add 'theme: larug.css' to your site or article YAML 

See docs at https://rstudio.github.io/distill/website.html#theming
```