### PR TITLE
override bootstrap viewport to move postcard content closer to top nav

### DIFF
--- a/inst/rmarkdown/templates/distill_article/resources/navbar.html
+++ b/inst/rmarkdown/templates/distill_article/resources/navbar.html
@@ -332,4 +332,10 @@ d-title {
   top: 0;
 }
 
+/* adjust viewport for navbar height */
+/* helps vertically center bootstrap (non-distill) content */
+.min-vh-100 {
+	min-height: calc(100vh - 100px) !important;
+}
+
 </style>


### PR DESCRIPTION
Hi @jjallaire -

This is a bit of a quick fix. I imagine javascript could be a better solution at some point, but it works 😉 

Embedded postcard: https://apreshill.github.io/postcard/about.html

Non-embedded postcard: https://apreshill.github.io/postcard/jolla-about/jolla-about.html

(also demo version: https://seankross.com/postcards-templates/jolla/)