### PR TITLE
find default branch from url's owner and repo when importing a post

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: distill
 Title: 'R Markdown' Format for Scientific and Technical Writing
-Version: 1.1.1
+Version: 1.1.2
 Authors@R: c(
     person("JJ", "Allaire", role = c("aut", "cre"), email = "jj@rstudio.com",
            comment = c(ORCID = "0000-0003-0174-9868")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## distill v1.2 (Development)
 
+-   Definitely fix issue w/ importing articles from git repos with `main` default branch. (\#215)
 -   Fix an issue with highlighting on Windows when there is a space in the resource's path (\#236).
 -   Add optional cookie consent overlay for opt-in to Google Analytics and Disqus.
 -   Support for including pages that use alternate R Markdown formats within Distill websites.

--- a/R/import.R
+++ b/R/import.R
@@ -362,7 +362,7 @@ resolve_github_url <- function(url, article_tmp) {
     repo <- matches[[1]][[3]]
 
     # determine the default branch
-    branches <- jsonlite::fromJSON("https://api.github.com/repos/rstudio/distill")
+    branches <- jsonlite::fromJSON(sprintf("https://api.github.com/repos/%s/%s", owner, repo))
     branch <- branches$default_branch
 
     # download the file list as json


### PR DESCRIPTION
This is missing to fix #215 

It was reported after the initial fix in the community 
https://community.rstudio.com/t/issues-with-distill-import-post-404-error/91382/4

I think the default branch should retrieve from the url and not always from rstudio/distill 

