### PR TITLE
Update documentation to reflect PR in rmarkdown to exclude renv directory

### DIFF
--- a/docs/blog.Rmd
+++ b/docs/blog.Rmd
@@ -496,7 +496,7 @@ When a blog post is published, resource files located alongside the post in its 
 
 2.  Files beginning with `"_"`
 
-3.  Files known to contain R source code (e.g. `".R"`, `".s"`, `".Rmd"`), R data (e.g. `".RData"`, `".rds"`), or configuration data (e.g. `"rsconnect"` ,`"packrat"`)).
+3.  Files known to contain R source code (e.g. `".R"`, `".s"`, `".Rmd"`), R data (e.g. `".RData"`, `".rds"`), or configuration data (e.g. `"rsconnect"` ,`"packrat"`, `"renv"`)).
 
 You can override this behavior using a `resources` metadata entry for your post, which can specify explicit files to `include` or `exclude`. For example (some fields excluded for brevity):
 

--- a/docs/website.Rmd
+++ b/docs/website.Rmd
@@ -101,7 +101,7 @@ The `include` and `exclude` fields enable you to override the default behavior v
 
 2.  Files beginning with `"_"`
 
-3.  Files known to contain R source code (e.g. `".R"`, `".s"`, `".Rmd"`), R data (e.g. `".RData"`, `".rds"`), or configuration data (e.g. `"rsconnect"` ,`"packrat"`)).
+3.  Files known to contain R source code (e.g. `".R"`, `".s"`, `".Rmd"`), R data (e.g. `".RData"`, `".rds"`), or configuration data (e.g. `"rsconnect"` ,`"packrat"`, `"renv"`)).
 
 The `include` and `exclude` fields of **\_site.yml** can be used to override this default behavior (wildcards can be used to specify groups of files to be included or excluded). Note that the `include` and `exclude` fields target only top-level files and directories (i.e. a directory is either included or not, you can't exclude a subset of files within a directory).
 


### PR DESCRIPTION
… in building the site.

The relevant PR I created for `rmarkdown` is here https://github.com/rstudio/rmarkdown/pull/1996

This will exclude the renv directory so that building the site does not copy it to the publish directory.
You might want to wait with approving this PR until the change is in the `rmarkdown` version used by distill.