### PR TITLE
Fix issue w/ UTF-8 encoded characters in site _footer.html

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 -   Fix issue w/ duplicate `includes` within website articles
 -   Suppress citation for individual articles/posts via `citation: false` metadata.
 -   Add `sourceCode` class to pre and code tags for downlit output.
+-   Fix issue w/ UTF-8 encoded characters in site \_footer.html
 
 ## distill v1.1 (CRAN)
 

--- a/R/navigation.R
+++ b/R/navigation.R
@@ -312,7 +312,7 @@ render_navigation_html <- function(navigation_html) {
 render_navigation_html_file <- function(navigation_html) {
   html <- render_navigation_html(navigation_html)
   file <- tempfile(fileext = "html")
-  writeLines(html, file)
+  writeLines(html, file, useBytes = TRUE)
   file
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -189,7 +189,9 @@ input_as_dir <- function(input) {
 }
 
 html_from_file <- function(file) {
-  HTML(readChar(file, nchars = file.info(file)$size, useBytes = TRUE))
+  contents <- readChar(file, nchars = file.info(file)$size, useBytes = TRUE)
+  Encoding(contents) <- "UTF-8"
+  HTML(contents)
 }
 
 html_file <- function(html) {


### PR DESCRIPTION
Fix for https://github.com/rstudio/distill/issues/98

@cderv Could you review?

