### PR TITLE
Fix author YAML and date formatting in create_post

### DIFF
--- a/R/create.R
+++ b/R/create.R
@@ -172,11 +172,12 @@ create_post <- function(title,
 title: "%s"
 description: |
   A short description of the post.
-%sdate: %s
+author: %s
+date: %s
 output:
   distill::distill_article:
     self_contained: false%s
----', title, author, format.Date(date, "%m-%d-%Y"), draft)
+---', title, author, format.Date(date, "%F"), draft)
 
 
   # body


### PR DESCRIPTION
Previously, if author was specified in `create_post()`, it was inserted without the `author: ` prefix in the YAML, giving an invalid header.

That is, `create_post('My title', author = 'John Smith')` would give a header of the form

```yaml
---
title: "My title"
description: |
  A short description of the post.
John Smith
date: 01-26-2021
output:
  distill::distill_article:
    self_contained: false
---
```

Also: the default month-day-year date formatting is not a standard used or understood by most of the world so I changed it to the more universal year-month-day format.

After both these fixes, the expected output is returned:

```yaml
---
title: "My title"
description: |
  A short description of the post.
author: John Smith
date: 2021-01-26
output:
  distill::distill_article:
    self_contained: false
---
```