### PR TITLE
Add support for references specified within YAML

### DIFF
--- a/R/appendices.R
+++ b/R/appendices.R
@@ -62,7 +62,7 @@ appendix_updates_and_corrections <- function(metadata) {
 }
 
 appendix_bibliography <- function(metadata) {
-  if (!is.null(metadata$bibliography)) {
+  if (!is.null(metadata$bibliography) | !is.null(metadata$references)) {
     list(
       tags$h3(id = "references", "References"),
       tags$div(id = "references-listing")

--- a/R/create.R
+++ b/R/create.R
@@ -155,8 +155,11 @@ create_post <- function(title,
       author <- list(author = posts[[1]]$author)
   }
   # if we still don't have an author then auto-detect
-  if (is.null(author))
+  if (is.null(author)) {
     author <- list(author = list(list(name = fullname(fallback = "Unknown"))))
+  } else { # if author is given as argument to function
+    author <- list(author = author)
+  }
   # author to yaml
   author <- yaml::as.yaml(author, indent.mapping.sequence = TRUE)
 
@@ -172,8 +175,7 @@ create_post <- function(title,
 title: "%s"
 description: |
   A short description of the post.
-author: %s
-date: %s
+%sdate: %s
 output:
   distill::distill_article:
     self_contained: false%s


### PR DESCRIPTION
By default, a "References" section is generated in the footer if we specify a bibliography in an external `.bib` file and refer to it from the `bibliography` YAML field, but not if we manually add *inline* references to the `references` field of the header, as described at the start of https://rmarkdown.rstudio.com/authoring_bibliographies_and_citations.html. This commit aims to fix that.

For example, the following article does not get a proper **References** section in the footer unless this fix is applied.

```markdown
---
title: "test"
description: |
  A short description of the post.
author:
  - name: Unknown
date: 01-26-2021
references:
  - id: test
    author: Author Name
    title: Example article reference title
    type: article-journal
    issued:
      year: 2021
    DOI: 00000001
    container-title: Nature
output:
  distill::distill_article:
    self_contained: false
---


Some text in which we cite our source @test. Some text after the reference.
```