### PR TITLE
Fix another create_post author edge case

### DIFF
--- a/R/create.R
+++ b/R/create.R
@@ -157,7 +157,7 @@ create_post <- function(title,
   # if we still don't have an author then auto-detect
   if (is.null(author)) {
     author <- list(author = list(list(name = fullname(fallback = "Unknown"))))
-  } else { # if author is given as argument to function
+  } else if (is.character(author)) { # if author is given as argument to function
     author <- list(author = author)
   }
   # author to yaml


### PR DESCRIPTION
Prevent `author: author:` if author is not explictly specified, but fallback inserts an author in an existing post.