### PR TITLE
Use CRAN lubridate and remove workaround

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: distill
 Title: 'R Markdown' Format for Scientific and Technical Writing
-Version: 1.2
+Version: 1.2.1
 Authors@R: c(
     person("JJ", "Allaire", role = c("aut", "cre"), email = "jj@rstudio.com",
            comment = c(ORCID = "0000-0003-0174-9868")),
@@ -39,7 +39,7 @@ Imports:
     xfun (>= 0.2),
     htmltools, 
     jsonlite (>= 1.3), 
-    lubridate, 
+    lubridate (>= 1.7.9.2), 
     png, 
     mime, 
     rstudioapi, 

--- a/R/utils.R
+++ b/R/utils.R
@@ -72,15 +72,8 @@ parse_date <- function(date) {
 }
 
 safe_timezone <- function() {
-  # OS X Catalina (10.15.7) has a corrupt timezone database, protect
-  # against this by always returning UTC on OSX until we have a
-  # lubridate fix for this on CRAN
-  if (is_osx()) {
-    "UTC"
-  } else {
-    tz <- Sys.timezone()
-    ifelse(is.na(tz), "UTC", tz)
-  }
+  tz <- Sys.timezone()
+  ifelse(is.na(tz), "UTC", tz)
 }
 
 time_as_iso_8601 <- function(time) {


### PR DESCRIPTION
This will fix #315

The version of **lubridate** with a fix is now on CRAN. The workaround is no more needed.