### PR TITLE
require lubridate 1.7.10 for the fix w/ timezone db on MacOS

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,7 @@ Imports:
     xfun (>= 0.2),
     htmltools, 
     jsonlite (>= 1.3), 
-    lubridate, 
+    lubridate (>= 1.7.10), 
     png, 
     mime, 
     rstudioapi, 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: distill
 Title: 'R Markdown' Format for Scientific and Technical Writing
-Version: 1.2.2
+Version: 1.2.3
 Authors@R: c(
     person("JJ", "Allaire", role = c("aut", "cre"), email = "jj@rstudio.com",
            comment = c(ORCID = "0000-0003-0174-9868")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## distill v1.3 (Development)
+
+-   Require **lubridate** 1.7.10 to fix an issue with timezone parsing on MacOS (\#315)
+
 ## distill v1.2 (CRAN)
 
 -   Support for optional user display of source code via the `code_folding` option.

--- a/R/utils.R
+++ b/R/utils.R
@@ -72,15 +72,8 @@ parse_date <- function(date) {
 }
 
 safe_timezone <- function() {
-  # OS X Catalina (10.15.7) has a corrupt timezone database, protect
-  # against this by always returning UTC on OSX until we have a
-  # lubridate fix for this on CRAN
-  if (is_osx()) {
-    "UTC"
-  } else {
-    tz <- Sys.timezone()
-    ifelse(is.na(tz), "UTC", tz)
-  }
+  tz <- Sys.timezone()
+  ifelse(is.na(tz), "UTC", tz)
 }
 
 time_as_iso_8601 <- function(time) {


### PR DESCRIPTION
This should finally fix #315 

lubridate 1.7.10 release on CRAN should contain the remaining part of the fix for the TZDIR issue on MacOS which causes parsing error. 

