### PR TITLE
categories needs to be URI decoded before filtering listing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: distill
 Title: 'R Markdown' Format for Scientific and Technical Writing
-Version: 1.2.3
+Version: 1.2.4
 Authors@R: c(
     person("JJ", "Allaire", role = c("aut", "cre"), email = "jj@rstudio.com",
            comment = c(ORCID = "0000-0003-0174-9868")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## distill v1.3 (Development)
 
 -   Require **lubridate** 1.7.10 to fix an issue with timezone parsing on MacOS (\#315)
+-   Listing pages are correctly filtered when using categories with special characters, encoded in URI (\#332)
 
 ## distill v1.2 (CRAN)
 

--- a/inst/rmarkdown/templates/distill_article/resources/listing.html
+++ b/inst/rmarkdown/templates/distill_article/resources/listing.html
@@ -54,6 +54,7 @@ function init_posts_list() {
 
       // mark posts that match the category visible
       var page_category = window.location.hash.replace(/^#category:/, "");
+      page_category = decodeURIComponent(page_category)
       var posts = $('.post-metadata').map(function(idx, script) {
         var metadata = $.parseJSON($(script).html());
         var post = null;
@@ -69,7 +70,7 @@ function init_posts_list() {
       set_posts_visible(posts, true);
 
       // mark the hash active
-      $('.categories li>a[href="' + window.location.hash + '"]').addClass('active');
+      $('.categories li>a[href="' + decodeURIComponent(window.location.hash) + '"]').addClass('active');
 
       // update the list_caption
       var list_caption = $('.posts-list-caption');


### PR DESCRIPTION
This fixes #331 

When catégories have special caractère which are URI encoded in the location hash, JS script needs to decode the URI in order to filter the listing page and update the content. 