### PR TITLE
use xfun::relative_path to get article relative path to site_dir

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,14 +1,14 @@
 ## distill v1.3 (Development)
 
--   Require **lubridate** 1.7.10 to fix an issue with timezone parsing on MacOS (\#315)
--   Listing pages are correctly filtered when using categories with special characters, encoded in URI (\#332)
+-   Require **lubridate** 1.7.10 to fix an issue with timezone parsing on MacOS (\#315).
+-   Listing pages are correctly filtered when using categories with special characters, encoded in URI (\#332).
 -   **distill** now works with project folder containing special characters (\#148).
 
 ## distill v1.2 (CRAN)
 
 -   Support for optional user display of source code via the `code_folding` option.
 -   Display citation popup when hovering over references.
--   Definitely fix issue w/ importing articles from git repos with `main` default branch. (\#215)
+-   Definitely fix issue w/ importing articles from git repos with `main` default branch (\#215).
 -   Fix an issue with highlighting on Windows when there is a space in the resource's path (\#236).
 -   Add optional cookie consent overlay for opt-in to Google Analytics and Disqus.
 -   Support for including pages that use alternate R Markdown formats within Distill websites.

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 -   Require **lubridate** 1.7.10 to fix an issue with timezone parsing on MacOS (\#315)
 -   Listing pages are correctly filtered when using categories with special characters, encoded in URI (\#332)
+-   **distill** now works with project folder containing special characters (\#148).
 
 ## distill v1.2 (CRAN)
 

--- a/R/collections.R
+++ b/R/collections.R
@@ -430,7 +430,7 @@ render_collection_article <- function(site_dir, site_config, collection, article
                                       quiet = FALSE) {
 
   # strip site_dir prefix
-  article_site_path <- collection_article_site_path(site_dir, article$path)
+  article_site_path <- xfun::relative_path(article$path, site_dir, use.. = FALSE)
 
   # determine the target output dir
   output_dir <- collection_article_output_dir(site_dir, site_config, article_site_path)
@@ -748,7 +748,7 @@ strip_trailing_newline <- function(x) {
 }
 
 collection_article_site_path <- function(site_dir, article_path) {
-  sub(paste0("^", site_dir, "/"), "", article_path)
+  xfun::relative_path(article_path, site_dir)
 }
 
 collection_article_output_dir <- function(site_dir, site_config, article_site_path) {

--- a/R/collections.R
+++ b/R/collections.R
@@ -747,10 +747,6 @@ strip_trailing_newline <- function(x) {
     x
 }
 
-collection_article_site_path <- function(site_dir, article_path) {
-  xfun::relative_path(article_path, site_dir)
-}
-
 collection_article_output_dir <- function(site_dir, site_config, article_site_path) {
   file.path(site_dir,
             site_config$output_dir,


### PR DESCRIPTION
This fixes #148 

Tested with this code: 
````r
# using a distill version without the fix
# we get the error
library(distill)
dir_name <- "Oh (No)"
dir.create(tmp_dir <- tempfile())
withr::with_tempdir({
  create_blog(dir_name, title = "Oh No", edit = FALSE)
})

rstudioapi::restartSession()

# Using this PR branch
# No more error
pkgload::load_all(".")
dir_name <- "Oh (No)"
dir.create(tmp_dir <- tempfile())
withr::with_tempdir({
  create_blog(dir_name, title = "Oh No", edit = FALSE)
})
````