### PR TITLE
Tweak arrow.theme for non-downlit syntax highlighting

### DIFF
--- a/inst/rmarkdown/templates/distill_article/resources/arrow.theme
+++ b/inst/rmarkdown/templates/distill_article/resources/arrow.theme
@@ -187,7 +187,7 @@
             "underline": false
         },
         "SpecialChar": {
-            "text-color": "#20794D",
+            "text-color": "#5E5E5E",
             "background-color": null,
             "bold": false,
             "italic": false,

--- a/inst/rmarkdown/templates/distill_article/resources/arrow.theme
+++ b/inst/rmarkdown/templates/distill_article/resources/arrow.theme
@@ -12,7 +12,7 @@
             "underline": false
         },
         "Attribute": {
-            "text-color": "#20794D",
+            "text-color": null,
             "background-color": null,
             "bold": false,
             "italic": false,


### PR DESCRIPTION
Preview of how the syntax highlighting will look with these tweaks & downlit turned off:

https://apreshill.github.io/rmda11y/arrow.html