### PR TITLE
let `html_document_base()` handle css argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     utils,
     stats,
     tools,
-    rmarkdown (>= 2.6),
+    rmarkdown (>= 2.7.10),
     bookdown (>= 0.8),
     xfun (>= 0.2),
     htmltools, 
@@ -62,5 +62,6 @@ Suggests:
     rsconnect,
     testthat (>= 3.0.0),
     withr
+Remotes: rstudio/rmarkdown
 Language: en-US
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 -   Listing pages are correctly filtered when using categories with special characters, encoded in URI (\#332).
 -   **distill** now works with project folder containing special characters (\#148).
 -   Improved handling for citations with multiple ids (show popup and include in Google Scholar metadata).
+-   `css` argument in `distill_article()` now supports new feature from `rmarkdown::html_document_base()` and will compile to CSS any `.scss` or `.sass` file.
 
 ## distill v1.2 (CRAN)
 

--- a/R/distill_article.R
+++ b/R/distill_article.R
@@ -139,10 +139,6 @@ distill_article <- function(toc = FALSE,
     # pandoc args
     args <- c()
 
-    # additional user css
-    for (css_file in css)
-      args <- c(args, "--css", pandoc_path_arg(css_file))
-
     # compute knitr output file
     output_file <- file_with_meta_ext(input_file, "knit", "md")
 
@@ -299,6 +295,7 @@ distill_article <- function(toc = FALSE,
       smart = smart,
       self_contained = self_contained,
       lib_dir = lib_dir,
+      css = css,
       mathjax = mathjax,
       template = "default",
       pandoc_args = pandoc_args,

--- a/R/distill_article.R
+++ b/R/distill_article.R
@@ -10,6 +10,8 @@
 #'
 #' @inheritParams rmarkdown::html_document
 #'
+#' @param css CSS and/or Sass files to include. Files with an extension of `.sass` or
+#'  `.scss` are compiled to CSS via `sass::sass()`.
 #' @param toc_float Float the table of contents to the left when the article
 #'   is displayed at widths > 1000px. If set to `FALSE` or the width is less
 #'   than 1000px the table of contents will be placed above the article body.

--- a/man/distill_article.Rd
+++ b/man/distill_article.Rd
@@ -87,7 +87,8 @@ base R Markdown HTML output formatter \code{\link[rmarkdown]{html_document_base}
 
 \item{theme}{CSS file with theme variable definitions}
 
-\item{css}{One or more css files to include}
+\item{css}{CSS and/or Sass files to include. Files with an extension of \code{.sass} or
+\code{.scss} are compiled to CSS via \code{sass::sass()}.}
 
 \item{includes}{Named list of additional content to include within the
 document (typically created using the \code{\link[rmarkdown]{includes}} function).}


### PR DESCRIPTION
This will close #359 

In **rmarkdown**, `css` argument is now handled directly in `html_document_base` and will by default process any `.scss` or `.sass` file with `sass::sass()` when **sass** 📦 is available. 

If a `.css` it will pass it as-is to Pandoc argument. If a `.scss` or `.sass` it will be processed by `sass::sass()` to compile `.css` file than will be used as Pandoc's arg.

@apreshill you're example should work now

````markdown
---
title: "Untitled"
date: 2020-12-18
output: 
  distill::distill_article: 
    css: styles.scss
---

```{cat, engine.opts = list(file = "style.scss")}
$green: #212D2C;
$sky: #A9FDFF;
$cyan: #36C9B4;

.my-color {
  background-color: $green;
  color: $sky;
  padding: 1em;
}
.my-link a {
  @extend .my-color;
  color: $cyan;
  &:hover {
      background-color: rgba( $green, .5 );
      color: white;
  }
}
```

::: {.my-link}
This is a link that will be [cyan](https://pkgs.rstudio.com/rmarkdown/), but you can read more in [[The Cookbook]{#cookbook}](https://bookdown.org/yihui/rmarkdown-cookbook/).
:::
````

![image](https://user-images.githubusercontent.com/6791940/115244315-1baab900-a124-11eb-916d-a75db7a315f7.png)

