### PR TITLE
Use `read_html()` on `_footer.html`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## distill v1.3 (Development)
 
+-   Fix issue w/ `_footer.html` containing HTML tags using attributes with no value (\#377).
 -   Require **lubridate** 1.7.10 to fix an issue with timezone parsing on MacOS (\#315).
 -   Listing pages are correctly filtered when using categories with special characters, encoded in URI (\#332).
 -   **distill** now works with project folder containing special characters (\#148).

--- a/R/navigation.R
+++ b/R/navigation.R
@@ -280,7 +280,7 @@ fixup_navigation_paths <- function(file, site_dir, site_config, offset) {
     fixup_element_paths(html, "a", "href")
     fixup_element_paths(html, "img", "src")
     tmp <- tempfile(fileext = ".html")
-    xml2::write_xml(html, tmp, options = c("format", "no_declaration"))
+    xml2::write_html(html, tmp, options = c("format", "no_declaration"))
     file <- tmp
   }
 

--- a/R/navigation.R
+++ b/R/navigation.R
@@ -276,7 +276,7 @@ fixup_navigation_paths <- function(file, site_dir, site_config, offset) {
 
   # process if necessary
   if (!is.null(offset)) {
-    html <- xml2::read_xml(file)
+    html <- xml2::read_html(file)
     fixup_element_paths(html, "a", "href")
     fixup_element_paths(html, "img", "src")
     tmp <- tempfile(fileext = ".html")


### PR DESCRIPTION
close #377

Error was cause by nodes with attributes having no values, which valid in HTML but not in XML

````markdown
tmp <- tempfile()
xfun::write_utf8(
  '<script async defer data-domain="koaning.io" src="https://plausible.io/js/plausible.js"></script>',
  tmp)
xml2::read_xml(tmp)
#> Error in read_xml.character(tmp): Specification mandates value for attribute async [41]
xml2::read_html(tmp)
#> {html_document}
#> <html>
#> [1] <head>\n<meta http-equiv="Content-Type" content="text/html; charset=UTF-8 ...
unlink(tmp)
````