### PR TITLE
Fix RSS feed with full content 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## distill v1.3 (Development)
 
+-   Fix issue w/ full content and categorized rss feed (\#380).
 -   Require **lubridate** 1.7.10 to fix an issue with timezone parsing on MacOS (\#315).
 -   Listing pages are correctly filtered when using categories with special characters, encoded in URI (\#332).
 -   **distill** now works with project folder containing special characters (\#148).

--- a/R/sitemap.R
+++ b/R/sitemap.R
@@ -245,7 +245,7 @@ write_feed_xml <- function(feed_xml, site_config, collection, articles) {
 
     full_content_path <- NULL
     if (identical(site_config$rss$full_content, TRUE) && is.character(article$input_file)) {
-      guess_rmd <- paste0(gsub("\\.utf.*\\.md|\\.md", "", article$input_file), ".Rmd")
+      guess_rmd <- paste0(gsub("\\.(utf|knit).*\\.md|\\.md", "", article$input_file), ".Rmd")
       full_content_path <- dir(getwd(), pattern = guess_rmd, full.names = TRUE, recursive = TRUE)
     }
 

--- a/R/sitemap.R
+++ b/R/sitemap.R
@@ -143,7 +143,7 @@ write_feed_xml_html_content <- function(input_path, article, site_config) {
                     ))
 
   # read contents
-  html_contents <- paste(readLines(html_file), collapse = "\n")
+  html_contents <- paste(xfun::read_utf8(html_file), collapse = "\n")
 
   # fix image paths
   html_contents <- gsub(paste0(basename(dirname(rmd_file)), "/"),


### PR DESCRIPTION
Fix #376

At least one issue is a change in rmarkdown 2.8 that broke it, but it may not be the only issue. We'll see.