### PR TITLE
Add CSS code in template for new citeproc style

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## distill v1.3 (Development)
 
+-   Fix references style by adding CSS rules used in Pandoc for citeproc.
 -   Fix issue w/ full content and categorized rss feed (\#380).
 -   Fix issue w/ `_footer.html` containing HTML tags using attributes with no value (\#377).
 -   Require **lubridate** 1.7.10 to fix an issue with timezone parsing on MacOS (\#315).

--- a/inst/rmarkdown/templates/distill_article/resources/default.html
+++ b/inst/rmarkdown/templates/distill_article/resources/default.html
@@ -28,6 +28,33 @@ $highlighting-css$
 </style>
 $endif$
 
+$if(csl-css)$
+<style>
+  div.csl-bib-body { }
+  div.csl-entry {
+    clear: both;
+  $if(csl-entry-spacing)$
+    margin-bottom: $csl-entry-spacing$;
+  $endif$
+  }
+  .hanging div.csl-entry {
+    margin-left:2em;
+    text-indent:-2em;
+  }
+  div.csl-left-margin {
+    min-width:2em;
+    float:left;
+  }
+  div.csl-right-inline {
+    margin-left:2em;
+    padding-left:1em;
+  }
+  div.csl-indent {
+    margin-left: 2em;
+  }
+</style>
+$endif$
+
 $for(header-includes)$
   $header-includes$
 $endfor$


### PR DESCRIPTION
**distill** does not currently have the CSS rules inserted by Pandoc for the references part created by citeproc 

https://github.com/jgm/pandoc/blob/06408d08e5ccf06a6a04c9b77470e6a67d98e52c/data/templates/styles.html#L157-L180

This will be inserted now in the template when `--citeproc` is used, and it will apply on the div and other parts created by Pandoc for references.

Test file

````markdown
---
title: "About"
bibliography: packages.bib
csl: https://www.zotero.org/styles/nature-communications
output: distill::distill_article
---

```{r, include = FALSE}
knitr::write_bib(c("rmarkdown", "knitr"), "packages.bib")
```

See knitr [@knitr2014] and rmarkdown @R-rmarkdown
````

This deals with one feedback in #392 