### PR TITLE
do not specify encoding in readLines() when reading from connection

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: distill
 Title: 'R Markdown' Format for Scientific and Technical Writing
-Version: 1.3.1
+Version: 1.3.2
 Authors@R: c(
     person("JJ", "Allaire", role = c("aut", "cre"), email = "jj@rstudio.com",
            comment = c(ORCID = "0000-0003-0174-9868")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # distill (development version)
 
+-   Fix an issue when discovering a preview image with UTF-8 characters in its caption (thanks, @egodrive, #436).
+
 -   Improve WAVE assessment of output by adding `aria-hidden` on icon and setting `aria-label` on wrapping link (thanks, @batpigandme, #426).
 
 # distill v1.3 (CRAN)

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -752,7 +752,7 @@ discover_preview <- function(file) {
   while (!completed) {
 
     # read next 500 lines
-    lines <- readLines(con, n = 500, encoding = "UTF-8")
+    lines <- readLines(con, n = 500)
     if (length(lines) == 0)
       break
 


### PR DESCRIPTION
It won't have the expected effect when the connection already specify `encoding = UTF-8`. 

The `encoding` argument in `readLines()` seems only useful when the connection to the file is not yet opened.

This fixes #436 