### PR TITLE
Remove distill footnote tooltip when a note style CSL is used

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # distill (development version)
 
+-   Fix an issue with double tooltip on hover when a note style CSL is used for references (thanks, @sj-io, #423).
+
 -   Fix an issue when discovering a preview image with UTF-8 characters in its caption (thanks, @egodrive, #436).
 
 -   Improve WAVE assessment of output by adding `aria-hidden` on icon and setting `aria-label` on wrapping link (thanks, @batpigandme, #426).

--- a/inst/rmarkdown/templates/distill_article/resources/distill.html
+++ b/inst/rmarkdown/templates/distill_article/resources/distill.html
@@ -1140,6 +1140,12 @@ function init_distill() {
 
     // hoverable references
     $('span.citation[data-cites]').each(function() {
+      if ($(this).children()[0].nodeName == "D-FOOTNOTE") {
+        var fn = $(this).children()[0]
+        $(this).html(fn.shadowRoot.querySelector("sup"))
+        $(this).id = fn.id
+        fn.remove()
+      }
       var refs = $(this).attr('data-cites').split(" ");
       var refHtml = refs.map(function(ref) {
         return "<p>" + $('#ref-' + ref).html() + "</p>";


### PR DESCRIPTION
This fixes #423 

When a note style CSL is used, Pandoc will create a footnote for this reference. _distill.js_ will then handle this as a regular footnote and create a tooltip on hover. After that, **distill** R package will create a tooltip for the reference as it is a feature with any CSL. 
This creates a double tooltip on hover. 

This PR specifically handle the `d-footnote` element in the reference Span when citation are processed by **distill**.
The `d-footnote` is removed in the post process and replaced by usual tooltip with reference content. 