### PR TITLE
Correct encoding support in _footer.html insertion

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: distill
 Title: 'R Markdown' Format for Scientific and Technical Writing
-Version: 1.3.2
+Version: 1.3.3
 Authors@R: c(
     person("JJ", "Allaire", , "jj@rstudio.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0174-9868")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,12 @@
 # distill (development version)
 
--   Fix an issue with double tooltip on hover when a note style CSL is used for references (thanks, @sj-io, #423).
+-   Fix an issue with encoding when inserting `_footer.html` in posts (thanks, \@shikokuchuo, #417).
 
--   Fix an issue when discovering a preview image with UTF-8 characters in its caption (thanks, @egodrive, #436).
+-   Fix an issue with double tooltip on hover when a note style CSL is used for references (thanks, \@sj-io, #423).
 
--   Improve WAVE assessment of output by adding `aria-hidden` on icon and setting `aria-label` on wrapping link (thanks, @batpigandme, #426).
+-   Fix an issue when discovering a preview image with UTF-8 characters in its caption (thanks, \@egodrive, #436).
+
+-   Improve WAVE assessment of output by adding `aria-hidden` on icon and setting `aria-label` on wrapping link (thanks, \@batpigandme, #426).
 
 # distill v1.3 (CRAN)
 

--- a/R/navigation.R
+++ b/R/navigation.R
@@ -276,7 +276,7 @@ fixup_navigation_paths <- function(file, site_dir, site_config, offset) {
 
   # process if necessary
   if (!is.null(offset)) {
-    html <- xml2::read_html(file)
+    html <- xml2::read_html(file, encoding = "UTF-8")
     fixup_element_paths(html, "a", "href")
     fixup_element_paths(html, "img", "src")
     tmp <- tempfile(fileext = ".html")


### PR DESCRIPTION
When processing rendered footer, be sure to read as UTF-8

This close #417 