### PR TITLE
Do not write search file if search is deactivated in config

### DIFF
--- a/R/distill_website.R
+++ b/R/distill_website.R
@@ -88,7 +88,10 @@ distill_website <- function(input, encoding = getOption("encoding"), ...) {
       write_sitemap_xml(input, config)
 
       # write top level article search index
-      write_search_json(input, config)
+      # if search is activated
+      if (site_search_enabled(config)) {
+        write_search_json(input, config)
+      }
 
       # return result
       result


### PR DESCRIPTION
Related to #425

If search is deactivated in YAML config (https://rstudio.github.io/distill/website.html#site-search), we do not write the `search.json` file

