### PR TITLE
Correctly find the Rmd article source for the full content feed

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: distill
 Title: 'R Markdown' Format for Scientific and Technical Writing
-Version: 1.3.8
+Version: 1.3.9
 Authors@R: c(
     person("JJ", "Allaire", , "jj@rstudio.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0174-9868")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ Imports:
     tools,
     utils,
     whisker,
-    xfun (>= 0.2),
+    xfun (>= 0.18),
     xml2,
     yaml
 Suggests:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # distill (development version)
 
+-   Fix an issue with `full_content: true` for RSS feed creation (thanks, \\\@yuryzablotski, #454).
 -   Footnotes inserted in tables have now their tooltip correctly place (thanks, \\\@RMRubert, #411).
 -   Fix an issue with Leaflet Markers not showing when using non default layout (thanks, \\\@AndersFenger, #106).
 -   `code_folding = FALSE` set on a chunk is now correctly taken into account and does not enforce `echo = TRUE`. As a reminder, setting `code_folding: true` in YAML header will enforce `echo = TRUE` on chunk, unless `code_folding` is unset on a per-chunk basis (thanks, \\\@werkstattcodes, #297).

--- a/R/sitemap.R
+++ b/R/sitemap.R
@@ -246,7 +246,14 @@ write_feed_xml <- function(feed_xml, site_config, collection, articles) {
     full_content_path <- NULL
     if (identical(site_config$rss$full_content, TRUE) && is.character(article$input_file)) {
       guess_rmd <- paste0(gsub("\\.(utf|knit).*\\.md|\\.md", "", article$input_file), ".Rmd")
-      full_content_path <- dir(getwd(), pattern = guess_rmd, full.names = TRUE, recursive = TRUE)
+      full_content_path <- tryCatch(
+        xfun::magic_path(guess_rmd, root = getwd(), relative = TRUE, error = TRUE, message = FALSE),
+        error = function(e) {
+          warning("Could not find the path ", sQuote(guess_rmd), " to build full content RSS feed for HTML page ", sQuote(article$path),
+                  ". Only simple content will be inserted for this article in RSS feed.")
+          NULL
+        }
+      )
     }
 
     if (length(full_content_path) > 0) {

--- a/R/sitemap.R
+++ b/R/sitemap.R
@@ -247,6 +247,7 @@ write_feed_xml <- function(feed_xml, site_config, collection, articles) {
     if (identical(site_config$rss$full_content, TRUE) && is.character(article$input_file)) {
       guess_rmd <- paste0(gsub("\\.(utf|knit).*\\.md|\\.md", "", article$input_file), ".Rmd")
       full_content_path <- tryCatch(
+        # will found the first file that match, which should be in a collection folder "_*"
         xfun::magic_path(guess_rmd, root = getwd(), relative = TRUE, error = TRUE, message = FALSE),
         error = function(e) {
           warning("Could not find the path ", sQuote(guess_rmd), " to build full content RSS feed for HTML page ", sQuote(article$path),


### PR DESCRIPTION
Fixes #454 

 It seems we had a hidden issue in our workflow that has been unveiled by the fact you two posts with same end of name are found among the project post. This creates unhandled conflict. I think my fix will solves this. 

The whole RSS feed process should be rethink IMO (https://github.com/rstudio/distill/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+RSS)