### PR TITLE
Remove CSS rule so that `out.width` can be applied on a chunk

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: distill
 Title: 'R Markdown' Format for Scientific and Technical Writing
-Version: 1.3.10
+Version: 1.3.11
 Authors@R: c(
     person("JJ", "Allaire", , "jj@rstudio.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0174-9868")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # distill (development version)
 
+-   Fix an issue prevent sizing of figures produced with **knitr** using `out.width` chunk option (thanks, \\\@ssp3nc3r, #286).
 -   Fix an issue with running `targets::tar_render()` with a distill Rmd document (thanks, \\\@tarensanders, #400)
 -   Fix an issue with `full_content: true` for RSS feed creation (thanks, \\\@yuryzablotski, #454).
 -   Footnotes inserted in tables have now their tooltip correctly place (thanks, \\\@RMRubert, #411).

--- a/inst/rmarkdown/templates/distill_article/resources/distill.html
+++ b/inst/rmarkdown/templates/distill_article/resources/distill.html
@@ -307,10 +307,6 @@ figure img.external {
   margin-top: 1.5em;
 }
 
-.figure img {
-  width: 100%;
-}
-
 .figure .caption {
   color: rgba(0, 0, 0, 0.6);
   font-size: 12px;


### PR DESCRIPTION
fix #286. This seems possible as width is also set / unset in JS for knitr plot output

https://github.com/rstudio/distill/blob/0e06b3f7d2b3aafcdb0f3038b6573330df2d45dc/inst/rmarkdown/templates/distill_article/resources/distill.html#L1285-L1296

This way the CSS rule would not take precedence over a CSS style value set on image using `out.width`