### PR TITLE
<script> and <style> are correctly ignored from search content

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: distill
 Title: 'R Markdown' Format for Scientific and Technical Writing
-Version: 1.3.12
+Version: 1.3.13
 Authors@R: c(
     person("JJ", "Allaire", , "jj@rstudio.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0174-9868")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # distill (development version)
 
+-   Content in `<script>` and `<style>` are now considered not searchable and exclude from content in `search.json`. This should make the json file a lot lighter and loading faster as htmlwidget code (e.g plotly graph) would correctly be not included (thanks, \\\@mitchelloharawild, #425).
 -   Fix an issue with `search.json` that was still written even when `search: false` in set in config (thanks, \\\@mitchelloharawild, #425).
 -   Fix an issue prevent sizing of figures produced with **knitr** using `out.width` chunk option (thanks, \\\@ssp3nc3r, #286).
 -   Fix an issue with running `targets::tar_render()` with a distill Rmd document (thanks, \\\@tarensanders, #400)

--- a/R/collections.R
+++ b/R/collections.R
@@ -875,6 +875,13 @@ article_contents <- function(path) {
     article_html <- xml2::xml_find_first(html, "//body")
   }
   if (!is.na(article_html)) {
+    # remove script tag content for article content
+    scripts <- xml2::xml_find_all(article_html, "//script")
+    xml2::xml_remove(scripts)
+    # remove style tag content for article content
+    style <- xml2::xml_find_all(article_html, "//style")
+    xml2::xml_remove(style)
+
     contents <- as_utf8(xml2::xml_text(article_html))
   }
   contents

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -1,3 +1,43 @@
-skip_if_pandoc_not_installed <- function() {
-  skip_if_not(rmarkdown::pandoc_available("2.0"), "pandoc >= 2.0 not available")
+local_rmd_file <- function(..., .env = parent.frame()) {
+  path <- withr::local_tempfile(.local_envir = .env, fileext = ".Rmd")
+  xfun::write_utf8(c(...), path)
+  path
 }
+
+local_render <- function(input, ..., .env = parent.frame()) {
+  skip_if_not_pandoc()
+  output_file <- withr::local_tempfile(.local_envir = .env)
+  rmarkdown::render(input, output_file = output_file, quiet = TRUE, ...)
+}
+
+.render_and_read <- function(input, ...) {
+  skip_if_not_pandoc()
+  output_file <- withr::local_tempfile()
+  res <- rmarkdown::render(input, output_file = output_file, quiet = TRUE, ...)
+  xfun::read_utf8(res)
+}
+
+# Use to test pandoc availability or version lower than
+skip_if_not_pandoc <- function(ver = "2.0") {
+  if (!rmarkdown::pandoc_available(ver)) {
+    msg <- if (is.null(ver)) {
+      "Pandoc is not available"
+    } else {
+      sprintf("Version of Pandoc is lower than %s.", ver)
+    }
+    skip(msg)
+  }
+}
+
+# Use to test version greater than
+skip_if_pandoc <- function(ver = "2.0") {
+  if (rmarkdown::pandoc_available(ver)) {
+    msg <- if (is.null(ver)) {
+      "Pandoc is available"
+    } else {
+      sprintf("Version of Pandoc is greater than %s.", ver)
+    }
+    skip(msg)
+  }
+}
+

--- a/tests/testthat/test-collections.R
+++ b/tests/testthat/test-collections.R
@@ -1,0 +1,12 @@
+test_that("script and style are not included as `article_content`", {
+  skip_on_cran()
+  skip_if_not_pandoc()
+  rmd <- local_rmd_file(c(
+    "---", "title: test", "---",
+    "Some content", "",
+    "<script> console.log('test')</script>", "",
+    "<style>h1 { color: red }</style>", ""
+  ))
+  html <- local_render(rmd, output_format = 'distill::distill_article')
+  expect_identical(str_trim(article_contents(html)), "Some content")
+})

--- a/tests/testthat/test-create.R
+++ b/tests/testthat/test-create.R
@@ -1,6 +1,6 @@
 test_that("blogs can be created", {
 
-  skip_if_pandoc_not_installed()
+  skip_if_not_pandoc()
 
   tmpdir <- withr::local_tempdir()
 
@@ -18,7 +18,7 @@ test_that("blogs can be created", {
 })
 
 test_that("websites can be created", {
-  skip_if_pandoc_not_installed()
+  skip_if_not_pandoc()
   expect_error({
     on.exit(unlink("testsite", recursive = TRUE), add = TRUE)
     create_website("testsite", "Test Site", edit = FALSE)

--- a/tests/testthat/test-distill_article.R
+++ b/tests/testthat/test-distill_article.R
@@ -1,5 +1,5 @@
 test_that("distill articles can be created", {
-  skip_if_pandoc_not_installed()
+  skip_if_not_pandoc()
   expect_s3_class(distill_article(), "rmarkdown_output_format")
 })
 


### PR DESCRIPTION
This should fix #425 

We were inserting every content text in the `search.json` which is too much and makes website slow.