### PR TITLE
Fix citation metadata for invalid bib year entry

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: distill
 Title: 'R Markdown' Format for Scientific and Technical Writing
-Version: 1.4.2
+Version: 1.4.3
 Authors@R: c(
     person("Christophe", "Dervieux", , "cderv@rstudio.com", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4474-2498")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # distill (development version)
 
+-   Fix an issue with bibliography and date parsing (thanks, \\\@mitchelloharawild, #468).
 -   Fix an issue with compatibility with Pandoc 2.17+ which were breaking some **bookdown** feature supported by **distill**, like text references (thanks, \@eliocamp, #463).
 -   Fix an issue with blank HTML in browser when a `@` is used unescaped in a document without `bibliography` YAML key (thanks, \@L-Groeninger, #466).
 

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -565,7 +565,7 @@ citation_reference <- function(ref) {
     add_field(name, ref[[name]])
   }
   add_ref_field("title")
-  if (!is.null(ref$issued))
+  if (length(ref$issued$`date-parts`) > 1)
     add_field("publication_date", ref[["issued"]][["date-parts"]][[1]][[1]])
   add_ref_field("publisher")
 


### PR DESCRIPTION
When pandoc fails to parse the year of a bibliography entry it creates an empty `issued$date-parts`.
This PR improves the check for the availability of `publication_date` metadata entry to work in these scenarios.

Example bib which currently errors (but is fixed with this change):

```
@Misc{gentleman,
  author={Robert Gentleman and Duncan {Temple Lang}},
  title={Statistical Analyses and Reproducible Research},
  year={May 2004},
  howpublished={Bioconductor Project Working Papers},
  number=2
}
```