### PR TITLE
Standardize Posit name

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,7 +12,7 @@ Authors@R: c(
            comment = c(ORCID = "0000-0002-8082-1890")),
     person("Yihui", "Xie", role = "aut",
            comment = c(ORCID = "0000-0003-0645-5666")),
-    person(, "RStudio, PBC", role = c("cph", "fnd")),
+    person(, "Posit Software, PBC", role = c("cph", "fnd")),
     person(, "Google LLC", role = c("ctb", "cph"),
            comment = "https://distill.pub/guide/"),
     person("Nick", "Williams", role = c("ctb", "cph"),


### PR DESCRIPTION
I scraped CRAN to find companies that fund R packages, and noticed that Posit is credited 6 different ways (9 if you include RStudio/RStudio PBC/RStudio, PBC). I'm submitting PRs with the official "Posit Software, PBC" name on the few Posit/PBC varieties to nip it in the bud.