### PR TITLE
Use format() instead of as.character()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: distill
 Title: 'R Markdown' Format for Scientific and Technical Writing
-Version: 1.5.2
+Version: 1.5.3
 Authors@R: c(
     person("Christophe", "Dervieux", , "cderv@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4474-2498")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # distill (development version)
 
 -   Fix an issue with line numbering on code chunks when `highlight-downlit: false` by tweaking Pandoc's default CSS rules (thanks, \@SES-CE, #473).
+-   Internally use `format()` instead of `as.character()` with Dates to account for argument \`format=\` deprecation in R 4.3.0 (thanks, \\\@mbojan, #488).
 
 # distill 1.5 (CRAN)
 

--- a/R/create.R
+++ b/R/create.R
@@ -326,7 +326,7 @@ resolve_post_dir <- function(posts_dir, slug, date_prefix) {
     else if (is.character(date_prefix))
       date_prefix <- parse_date(date_prefix)
     if (is_date(date_prefix)) {
-      date_prefix <- as.character(date_prefix, format = "%Y-%m-%d")
+      date_prefix <- format(date_prefix, format = "%Y-%m-%d")
     } else {
       stop("You must specify either NULL or a date for date_prefix")
     }

--- a/R/import.R
+++ b/R/import.R
@@ -86,15 +86,15 @@ import_article <- function(url, collection, slug = "auto",
   if (is.character(date))
     date <- parse_date(date)
   if (!is.null(date))
-    metadata$date <- as.character(date, format = "%m-%d-%Y")
+    metadata$date <- format(date, format = "%m-%d-%Y")
 
   # if there is still no date in metadata then assign today
   if (is.null(metadata$date))
-    metadata$date <- as.character(Sys.Date(), format = "%m-%d-%Y")
+    metadata$date <- format(Sys.Date(), format = "%m-%d-%Y")
 
   # add date to slug if requested
   if (isTRUE(date_prefix)) {
-    slug <- paste(as.character(parse_date(metadata$date), format = "%Y-%m-%d"), slug,
+    slug <- paste(format(parse_date(metadata$date), format = "%Y-%m-%d"), slug,
                   sep = "-")
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -105,14 +105,14 @@ fixup_iso_timezone <- function(time) {
 }
 
 date_today <- function() {
-  as.character(Sys.Date(), format = "%m-%d-%Y")
+  format(Sys.Date(), format = "%m-%d-%Y")
 }
 
 date_as_rfc_2822 <- function(date) {
   date <- as.Date(date, tz = "UTC")
   with_locale(
     new = c("LC_TIME" = ifelse(is_windows(), "English", "en_US.UTF-8")),
-    as.character(date, format = "%a, %d %b %Y %H:%M:%S %z", tz = "UTC")
+    format(date, format = "%a, %d %b %Y %H:%M:%S %z", tz = "UTC")
   )
 }
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -1,0 +1,4 @@
+test_that("date_as_rfc_2822", {
+  expect_equal(date_as_rfc_2822("2023-02-24"), "Fri, 24 Feb 2023 00:00:00 +0000")
+})
+


### PR DESCRIPTION
this is because R 4.3.0 deprecated the format argument.

`as.character.POSIXt` as already passing to `format()` so this should be backward compatible

closes #488 