### PR TITLE
handle empty description in articles json when creating the XML feed

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,9 @@
 # distill (development version)
 
+-   RSS feed creation now works correctly for listings when no `description` is provided in one of the Rmd post (thanks, \@cpsyctc, \@apeterson91, #490, #448).
 -   Fix an issue with line numbering on code chunks when `highlight-downlit: false` by tweaking Pandoc's default CSS rules (thanks, \@SES-CE, #473).
--   Internally use `format()` instead of `as.character()` with Dates to account for argument \`format=\` deprecation in R 4.3.0 (thanks, \\\@mbojan, #488).
--   Add a `subtitle` variable in HTML template placed between title and categories (thanks, \\\@dicook, #480).
+-   Internally use `format()` instead of `as.character()` with Dates to account for argument `format=` deprecation in R 4.3.0 (thanks, \@mbojan, #488).
+-   Add a `subtitle` variable in HTML template placed between title and categories (thanks, \@dicook, #480).
 
 # distill 1.5 (CRAN)
 

--- a/R/publish.R
+++ b/R/publish.R
@@ -3,15 +3,12 @@
 #'
 #' Publish a website to RStudio Connect
 #'
-#' @inheritParams rsconnect::deploySite
+#' @inheritParams rsconnect::deployApp
 #'
 #' @param site_dir Directory containing website. Defaults to current working directory.
 #' @param site_name Name for the site (names must be unique within an account). Defaults
 #'   to the `name` provided in `_site.yml` (or to the name of the site_dir if there is no
 #'   `name` specified).
-#' @param account Account to deploy application to. This parameter is only required for
-#'   the initial deployment of an application when there are multiple accounts configured
-#'   on the system.
 #' @param method Publishing method (currently only "rsconnect" is available)
 #' @param render `TRUE` to render the site locally before publishing.
 #' @param launch_browser If `TRUE`, the system's default web browser will be launched

--- a/R/sitemap.R
+++ b/R/sitemap.R
@@ -281,7 +281,7 @@ write_feed_xml <- function(feed_xml, site_config, collection, articles) {
       }
     }
     else {
-      add_child(item, "description", text = not_null(article$description, default = article$title))
+      add_child(item, "description", text = not_null_or_empty(article$description, default = article$title))
     }
 
     if (!is.null(article$categories)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -31,6 +31,13 @@ not_null <- function(x, default="") {
     x
 }
 
+not_null_or_empty <- function(x, default="") {
+  if (is.null(x) || length(x) == 0)
+    default
+  else
+    x
+}
+
 block_class = function(x){
   if (length(x) == 0) return()
   classes = unlist(strsplit(x, '\\s+'))

--- a/man/publish_website.Rd
+++ b/man/publish_website.Rd
@@ -23,9 +23,11 @@ to the \code{name} provided in \verb{_site.yml} (or to the name of the site_dir 
 
 \item{method}{Publishing method (currently only "rsconnect" is available)}
 
-\item{account}{Account to deploy application to. This parameter is only required for
-the initial deployment of an application when there are multiple accounts configured
-on the system.}
+\item{account, server}{Uniquely identify a remote server with either your
+user \code{account}, the \code{server} name, or both. If neither are supplied, and
+there are multiple options, you'll be prompted to pick one.
+
+Use \code{\link[rsconnect:accounts]{accounts()}} to see the full list of available options.}
 
 \item{render}{\code{TRUE} to render the site locally before publishing.}
 

--- a/man/publish_website.Rd
+++ b/man/publish_website.Rd
@@ -23,9 +23,6 @@ to the \code{name} provided in \verb{_site.yml} (or to the name of the site_dir 
 
 \item{method}{Publishing method (currently only "rsconnect" is available)}
 
-\item{server}{Server name. Required only if you use the same account name on
-multiple servers.}
-
 \item{account}{Account to deploy application to. This parameter is only required for
 the initial deployment of an application when there are multiple accounts configured
 on the system.}


### PR DESCRIPTION
NULL in R gives empty list in JSON (when read back). Testing for NULL was not correct to default for `title` when no `description` is provided.

This is now handled correctly and should avoid cryptic error from XML writing. Fix #490 and fix #448

The code base is from several years ago, so it is surprising that this was never reported before. Probably a non empty `description` has always been provided. 🤷  